### PR TITLE
Change MessageEvent to Event like the spec.

### DIFF
--- a/src/WebsocketClient.re
+++ b/src/WebsocketClient.re
@@ -83,7 +83,7 @@ module Websocket = {
     "bufferedAmount": int,
     "url": string,
     "protocol": string,
-    "readyState": string,
+    "readyState": int,
     "extensions": string,
     [@bs.meth] "close": Js.Undefined.t(string) => Js.Undefined.t(string) => unit,
     [@bs.meth] "send": 'msg => unit

--- a/src/WebsocketClient.re
+++ b/src/WebsocketClient.re
@@ -1,3 +1,9 @@
+module /*Open*/Event = {
+  type t;
+
+  include EventRe.Impl({ type nonrec t = t; });
+};
+
 module MessageEvent = {
   type t;
   type data('a);
@@ -70,7 +76,7 @@ module Websocket = {
 
   type t('msg) = {.
     [@bs.set] "binaryType": string,
-    [@bs.set] "onopen": MessageEvent.t => unit,
+    [@bs.set] "onopen": Event.t => unit,
     [@bs.set] "onerror": MessageEvent.t => unit,
     [@bs.set] "onclose": CloseEvent.t => unit,
     [@bs.set] "onmessage": MessageEvent.t => unit,


### PR DESCRIPTION
Source https://html.spec.whatwg.org/multipage/indices.html#event-open

I don't know the type of close event for websocket https://html.spec.whatwg.org/multipage/indices.html#event-error

Here is the source: https://html.spec.whatwg.org/multipage/web-sockets.html#feedback-from-the-protocol (scroll up a bit)
Also for message event the spec say `any` but MDN in french say
> `DOMString`, `Blob` ou un tableau `ArrayBuffer`

https://developer.mozilla.org/fr/docs/Web/API/MessageEvent#Properties

Should I had a classify function or it should be treated in userland ? From my test I receive only string.
I have received a Blob after sending a ArrayBuffer to https://www.websocket.org/echo.html.